### PR TITLE
Added ISO8601 formatter class

### DIFF
--- a/BrewApp.xcodeproj/project.pbxproj
+++ b/BrewApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		5E7EEF7D5E3B49EF9766FBAC /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A5644DD31EE42708B45078B /* libPods.a */; };
+		6965BD65198E89B20036DDB1 /* ISO8601DateFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 6965BD64198E89B20036DDB1 /* ISO8601DateFormatter.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		69DB31F7198CF76A004AD0CB /* PhaseCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 69DB31F5198CF76A004AD0CB /* PhaseCell.m */; };
 		69DB31F8198CF76A004AD0CB /* PhaseCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 69DB31F6198CF76A004AD0CB /* PhaseCell.xib */; };
 		69DB31FF198CFB3C004AD0CB /* BrewPhase.m in Sources */ = {isa = PBXBuildFile; fileRef = 69DB31FE198CFB3C004AD0CB /* BrewPhase.m */; };
@@ -41,6 +42,8 @@
 
 /* Begin PBXFileReference section */
 		2BC82EC0B23747D0B82AF874 /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = "<group>"; };
+		6965BD63198E89B20036DDB1 /* ISO8601DateFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ISO8601DateFormatter.h; sourceTree = "<group>"; };
+		6965BD64198E89B20036DDB1 /* ISO8601DateFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ISO8601DateFormatter.m; sourceTree = "<group>"; };
 		69DB31F4198CF76A004AD0CB /* PhaseCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PhaseCell.h; sourceTree = "<group>"; };
 		69DB31F5198CF76A004AD0CB /* PhaseCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PhaseCell.m; sourceTree = "<group>"; };
 		69DB31F6198CF76A004AD0CB /* PhaseCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PhaseCell.xib; sourceTree = "<group>"; };
@@ -123,6 +126,8 @@
 			children = (
 				69DB3207198D021B004AD0CB /* ContentParser.h */,
 				69DB3208198D021B004AD0CB /* ContentParser.m */,
+				6965BD63198E89B20036DDB1 /* ISO8601DateFormatter.h */,
+				6965BD64198E89B20036DDB1 /* ISO8601DateFormatter.m */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -350,6 +355,7 @@
 				69FA08B5198BB01B009CD802 /* AppDelegate.m in Sources */,
 				69FA08B1198BB01B009CD802 /* main.m in Sources */,
 				69DB3209198D021B004AD0CB /* ContentParser.m in Sources */,
+				6965BD65198E89B20036DDB1 /* ISO8601DateFormatter.m in Sources */,
 				69DB31F7198CF76A004AD0CB /* PhaseCell.m in Sources */,
 				69DB3202198CFD05004AD0CB /* BrewState.m in Sources */,
 			);

--- a/BrewApp/Controllers/BrewViewController.m
+++ b/BrewApp/Controllers/BrewViewController.m
@@ -83,14 +83,14 @@
 
 #pragma mark - Refreshing UI
 
-- (void)updateTempLabel:(NSNumber *)newTemp
-{
-    tempLabel.text = [NSString stringWithFormat:@"at %.2f ˚C, ", newTemp.floatValue];
-}
-
 - (void)updateNameLabel
 {
-    nameLabel.text = [NSString stringWithFormat:@"Brewing %@", actBrewState.name];
+    nameLabel.text = [NSString stringWithFormat:@"Brewing %@ at", actBrewState.name];
+}
+
+- (void)updateTempLabel:(NSNumber *)newTemp
+{
+    tempLabel.text = [NSString stringWithFormat:@"%.2f ˚C", newTemp.floatValue];
 }
 
 - (void)updateStartTimeLabel

--- a/BrewApp/Utils/ContentParser.h
+++ b/BrewApp/Utils/ContentParser.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "BrewState.h"
 #import "BrewPhase.h"
+#import "ISO8601DateFormatter.h"
 
 @interface ContentParser : NSObject
 

--- a/BrewApp/Utils/ContentParser.m
+++ b/BrewApp/Utils/ContentParser.m
@@ -74,10 +74,9 @@ static ContentParser *SharedInstance;
 - (NSString *)reformatDateString:(NSString *)rawDateString
 {
     NSString *timeString;
+    ISO8601DateFormatter *isoDateFormatter = [[ISO8601DateFormatter alloc] init];
+    NSDate *formattedDate = [isoDateFormatter dateFromString:rawDateString];
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-    [dateFormatter setDateFormat:@"yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSS'Z'"];
-    [dateFormatter setLocale:[NSLocale systemLocale]];
-    NSDate *formattedDate = [dateFormatter dateFromString:rawDateString];
     [dateFormatter setDateFormat:@"HH':'mm"];
     timeString = [dateFormatter stringFromDate:formattedDate];
     

--- a/BrewApp/Utils/ISO8601DateFormatter.h
+++ b/BrewApp/Utils/ISO8601DateFormatter.h
@@ -1,0 +1,222 @@
+/*ISO8601DateFormatter.h
+ *
+ *Created by Peter Hosey on 2009-04-11.
+ *Copyright 2009–2013 Peter Hosey. All rights reserved.
+ */
+
+#import <Foundation/Foundation.h>
+
+///Which of ISO 8601's three date formats the formatter should produce.
+typedef NS_ENUM(NSUInteger, ISO8601DateFormat) {
+	///YYYY-MM-DD.
+	ISO8601DateFormatCalendar,
+	///YYYY-DDD, where DDD ranges from 1 to 366; for example, 2009-32 is 2009-02-01.
+	ISO8601DateFormatOrdinal,
+	///YYYY-Www-D, where ww ranges from 1 to 53 (the 'W' is literal) and D ranges from 1 to 7; for example, 2009-W05-07.
+	ISO8601DateFormatWeek,
+};
+
+///The default separator for time values. Currently, this is ':'.
+extern const unichar ISO8601DefaultTimeSeparatorCharacter;
+
+/*!
+ *	@brief	This class converts dates to and from ISO 8601 strings.
+ *
+ *	@details	TL;DR: You want to use ISO 8601 for any and all dates you send or receive over the internet, unless the spec for the protocol or format you're working with specifically tells you otherwise. See http://xkcd.com/1179/ .
+ *
+ * ISO 8601 is most recognizable as “year-month-date” strings, such as “2013-09-08T15:06:11-0800”. Of course, as you might expect of a formal standard, it's more sophisticated (some might say complicated) than that.
+ *
+ * For one thing, ISO 8601 actually defines *three* different date formats. The most common one, shown above, is called the calendar date format. The other two are week dates, where the month is replaced by a week of the year and the day is a day-of-the-week (1 being Monday) rather than day-of-month, and ordinal dates, where the middle segment is dispensed with entirely and the day component is day-of-year (1–366).
+ *
+ * The week format is the most bizarre of them, since 7 × 52 ≠ 365. The start and end of the year for purposes of week dates usually don't line up with the start and end of the calendar year. As a result, the first and/or last day of a year in the week-date “calendar” more often than not is on a different year from the first and/or last day of that year on the actual Gregorian calendar.
+ *
+ * In practice, almost all ISO 8601 dates you see in the wild will be in the calendar format.
+ *
+ * At any rate, this formatter can both parse and unparse dates in all three formats. (By “unparse”, I mean “produce a string from”—the reverse of parsing.)
+ *
+ * For a good and more detailed introduction to ISO 8601, see [“A summary of the international standard date and time notation” by Markus Kuhn](http://www.cl.cam.ac.uk/~mgk25/iso-time.html). The actual standard itself can be found in PDF format online with a well-crafted web search.
+ */
+
+@interface ISO8601DateFormatter: NSFormatter
+{
+	NSString *lastUsedFormatString;
+	NSDateFormatter *unparsingFormatter;
+    
+	NSCalendar *parsingCalendar, *unparsingCalendar;
+    
+	NSTimeZone *defaultTimeZone;
+	ISO8601DateFormat format;
+	unichar timeSeparator;
+    unichar timeZoneSeparator;
+	BOOL includeTime;
+	BOOL parsesStrictly;
+}
+
+@property(nonatomic, retain) NSTimeZone *defaultTimeZone;
+
+#pragma mark Parsing
+/*!
+ *	@name	Parsing
+ */
+
+//As a formatter, this object converts strings to dates.
+
+/*!
+ *	@brief	Disables various leniencies in how the formatter parses strings.
+ *
+ *	@details	By default, the parser allows these extensions to the ISO 8601 standard:
+ *
+ * - Whitespace is allowed before the date.
+ * - Numbers don't have to be within range for a component. For example, you can have a string that refers to the 56th day of the hundredth month.
+ * - Since 0.6, allows a single whitespace character before the time-zone specification. This extension provides compatibility with NSDate output (`description`) and input (`dateWithString:`).
+ * - “Superfluous” hyphens in date specifications such as “`--DDD`” (where DDD is an ordinal day-of-year number and the year is implied) are allowed. (The standard recommends writing such a date as “`-DDD`”, with only a single hyphen. This is consistent with ordinal dates having only two components: the year and the day-of-year, separated by one hyphen.)
+ * - The same goes for week dates such as “`--Www-DD`”. Again, the extra hyphen really is superfluous, but is allowed as an extension.
+ * - Calendar dates with no separator between month and day-of-month are allowed, at least when they total four digits. (For example, 2013-0908, which would be interpreted as 2013-09-08.)
+ * - Single-digit components are allowed. (If you wish to specify a date in a single-digit year with the strict parser, pad it with zeroes.)
+ * - “YYYY-W” (without a week number after the 'W') is allowed, interpreted as “YYYY-W01-01”.
+ *
+ * Setting this property to `YES` will disable all of those extensions.
+ *
+ * These extensions are intended to help you process degenerate input (received from programs and services that use broken date-formatting libraries); whenever *you* create ISO 8601 strings, you should generate strictly-conforming ones.
+ *
+ * This property does not affect unparsing. The formatter always creates valid ISO 8601 strings. Any invalid string (loosely, any string that would require turning this property off to re-parse) should be considered a bug; please report it.
+ */
+@property BOOL parsesStrictly;
+
+/*!
+ *	@brief	Parse a string into individual date components.
+ *
+ *	@param	string	The string to parse. Must represent a date in one of the ISO 8601 formats.
+ *	@returns	An NSDateComponents object containing most of the information parsed from the string, aside from the fraction of second and time zone (which are lost).
+ *	@sa	dateComponentsFromString:timeZone:
+ *	@sa	dateComponentsFromString:timeZone:range:fractionOfSecond:
+ */
+- (NSDateComponents *) dateComponentsFromString:(NSString *)string;
+/*!
+ *	@brief	Parse a string into individual date components.
+ *
+ *	@param	string	The string to parse. Must represent a date in one of the ISO 8601 formats.
+ *	@param	outTimeZone	If non-`NULL`, an NSTimeZone object or `nil` will be stored here, depending on whether the string specified a time zone.
+ *	@returns	An NSDateComponents object containing most of the information parsed from the string, aside from the fraction of second (which is lost) and time zone.
+ *	@sa	dateComponentsFromString:
+ *	@sa	dateComponentsFromString:timeZone:range:fractionOfSecond:
+ */
+- (NSDateComponents *) dateComponentsFromString:(NSString *)string timeZone:(out NSTimeZone **)outTimeZone;
+/*!
+ *	@brief	Parse a string into individual date components.
+ *
+ *	@param	string	The string to parse. Must represent a date in one of the ISO 8601 formats.
+ *	@param	outTimeZone	If non-`NULL`, an NSTimeZone object or `nil` will be stored here, depending on whether the string specified a time zone.
+ *	@param	outRange	If non-`NULL`, an NSRange structure will be stored here, identifying the substring of `string` that specified the date.
+ *	@param	outFractionOfSecond	If non-`NULL`, an NSTimeInterval value will be stored here, containing the fraction of a second, if the string specified one. If it didn't, this will be set to zero.
+ *	@returns	An NSDateComponents object containing most of the information parsed from the string, aside from the fraction of second and time zone.
+ *	@sa	dateComponentsFromString:
+ *	@sa	dateComponentsFromString:timeZone:
+ */
+- (NSDateComponents *) dateComponentsFromString:(NSString *)string timeZone:(out NSTimeZone **)outTimeZone range:(out NSRange *)outRange fractionOfSecond:(NSTimeInterval *)outFractionOfSecond;
+
+/*!
+ *	@brief	Parse a string.
+ *
+ *	@param	string	The string to parse. Must represent a date in one of the ISO 8601 formats.
+ *	@returns	An NSDate object containing most of the information parsed from the string, aside from the time zone (which is lost).
+ *	@sa	dateComponentsFromString:
+ *	@sa	dateFromString:timeZone:
+ *	@sa	dateFromString:timeZone:range:
+ */
+- (NSDate *) dateFromString:(NSString *)string;
+/*!
+ *	@brief	Parse a string.
+ *
+ *	@param	string	The string to parse. Must represent a date in one of the ISO 8601 formats.
+ *	@param	outTimeZone	If non-`NULL`, an NSTimeZone object or `nil` will be stored here, depending on whether the string specified a time zone.
+ *	@returns	An NSDate object containing most of the information parsed from the string, aside from the time zone.
+ *	@sa	dateComponentsFromString:timeZone:
+ *	@sa	dateFromString:
+ *	@sa	dateFromString:timeZone:range:
+ */
+- (NSDate *) dateFromString:(NSString *)string timeZone:(out NSTimeZone **)outTimeZone;
+/*!
+ *	@brief	Parse a string into a single date, identified by an NSDate object.
+ *
+ *	@param	string	The string to parse. Must represent a date in one of the ISO 8601 formats.
+ *	@param	outTimeZone	If non-`NULL`, an NSTimeZone object or `nil` will be stored here, depending on whether the string specified a time zone.
+ *	@param	outRange	If non-`NULL`, an NSRange structure will be stored here, identifying the substring of `string` that specified the date.
+ *	@returns	An NSDate object containing most of the information parsed from the string, aside from the time zone.
+ *	@sa	dateComponentsFromString:timeZone:range:fractionOfSecond:
+ *	@sa	dateFromString:
+ *	@sa	dateFromString:timeZone:
+ */
+- (NSDate *) dateFromString:(NSString *)string timeZone:(out NSTimeZone **)outTimeZone range:(out NSRange *)outRange;
+
+#pragma mark Unparsing
+/*!
+ *	@name	Unparsing
+ */
+
+/*!
+ *	@brief	Which ISO 8601 format to format dates in.
+ *
+ *	@details	See ISO8601DateFormat for possible values.
+ */
+@property ISO8601DateFormat format;
+/*!
+ *	@brief	Whether strings should include time of day.
+ *
+ *	@details	If `NO`, strings include only the date, nothing after it.
+ *
+ *	@sa	timeSeparator
+ *	@sa	timeZoneSeparator
+ */
+@property BOOL includeTime;
+/*!
+ *	@brief	The character to use to separate components of the time of day.
+ *
+ *	@details	This is used in both parsing and unparsing.
+ *
+ * The default value is ISO8601DefaultTimeSeparatorCharacter.
+ *
+ * When parsesStrictly is set to `YES`, this property is ignored. Otherwise, the parser will raise an exception if this is set to zero.
+ *
+ *	@sa	includeTime
+ *	@sa	timeZoneSeparator
+ */
+@property unichar timeSeparator;
+/*!
+ *	@brief	The character to use to separate the hour and minute in a time zone specification.
+ *
+ *	@details	This is used in both parsing and unparsing.
+ *
+ * If zero, no separator is inserted into time zone specifications.
+ *
+ * The default value is zero (no separator).
+ *
+ *	@sa	includeTime
+ *	@sa	timeSeparator
+ */
+@property unichar timeZoneSeparator;
+
+/*!
+ *	@brief	Produce a string that represents a date in UTC.
+ *
+ *	@param	date	The string to parse. Must represent a date in one of the ISO 8601 formats.
+ *	@returns	A string that represents the date in UTC.
+ *	@sa	stringFromDate:timeZone:
+ */
+- (NSString *) stringFromDate:(NSDate *)date;
+/*!
+ *	@brief	Produce a string that represents a date.
+ *
+ *	@param	date	The string to parse. Must represent a date in one of the ISO 8601 formats.
+ *	@param	timeZone	An NSTimeZone object identifying the time zone in which to specify the date.
+ *	@returns	A string that represents the date in the requested time zone, if possible.
+ *
+ *	@details	Not all dates are representable in all time zones (because of historical calendar changes, such as transitions from the Julian to the Gregorian calendar).
+ *	For an example, see http://stackoverflow.com/questions/18663407/date-formatter-returns-nil-for-june .
+ *	This method *should* return `nil` in such cases.
+ *
+ *	@sa	stringFromDate:
+ */
+- (NSString *) stringFromDate:(NSDate *)date timeZone:(NSTimeZone *)timeZone;
+
+@end

--- a/BrewApp/Utils/ISO8601DateFormatter.m
+++ b/BrewApp/Utils/ISO8601DateFormatter.m
@@ -1,0 +1,1028 @@
+/*ISO8601DateFormatter.m
+ *
+ *Created by Peter Hosey on 2009-04-11.
+ *Copyright 2009–2013 Peter Hosey. All rights reserved.
+ */
+
+#import <float.h>
+#import <Foundation/Foundation.h>
+#if TARGET_OS_IPHONE
+#	import <UIKit/UIKit.h>
+#endif
+#import "ISO8601DateFormatter.h"
+
+#ifndef DEFAULT_TIME_SEPARATOR
+#	define DEFAULT_TIME_SEPARATOR ':'
+#endif
+const unichar ISO8601DefaultTimeSeparatorCharacter = DEFAULT_TIME_SEPARATOR;
+
+//Unicode date formats.
+#define ISO_CALENDAR_DATE_FORMAT @"yyyy-MM-dd"
+//#define ISO_WEEK_DATE_FORMAT @"YYYY-'W'ww-ee" //Doesn't actually work because NSDateComponents counts the weekday starting at 1.
+#define ISO_ORDINAL_DATE_FORMAT @"yyyy-DDD"
+#define ISO_TIME_FORMAT @"HH:mm:ss"
+//printf formats.
+#define ISO_TIMEZONE_UTC_FORMAT @"Z"
+#define ISO_TIMEZONE_OFFSET_FORMAT_NO_SEPARATOR @"%+.2d%.2d"
+#define ISO_TIMEZONE_OFFSET_FORMAT_WITH_SEPARATOR @"%+.2d%C%.2d"
+
+static NSString * const ISO8601TwoCharIntegerFormat = @"%.2d";
+
+@interface ISO8601DateFormatter ()
++ (void) createGlobalCachesThatDoNotAlreadyExist;
+//Used when a memory warning occurs (if at least one ISO 8601 Date Formatter exists at the time).
++ (void) purgeGlobalCaches;
+@end
+
+@interface ISO8601DateFormatter(UnparsingPrivate)
+
+- (NSString *) replaceColonsInString:(NSString *)timeFormat withTimeSeparator:(unichar)timeSep;
+
+- (NSString *) stringFromDate:(NSDate *)date formatString:(NSString *)dateFormat timeZone:(NSTimeZone *)timeZone;
+- (NSString *) weekDateStringForDate:(NSDate *)date timeZone:(NSTimeZone *)timeZone;
+
+@end
+
+@interface ISO8601TimeZoneCache: NSObject
+{}
+
+//The property being read-only means that the formatter cannot change the cache's dictionary, but the formatter is explicitly allowed to mutate the dictionary.
+@property(nonatomic, readonly, strong) NSMutableDictionary *timeZonesByOffset;
+
+@end
+
+static ISO8601TimeZoneCache *timeZoneCache;
+
+#if ISO8601_TESTING_PURPOSES_ONLY
+//This method only exists for use by the project's test cases. DO NOT use this in an application.
+extern bool ISO8601DateFormatter_GlobalCachesAreWarm(void);
+
+bool ISO8601DateFormatter_GlobalCachesAreWarm(void) {
+	return (timeZoneCache != nil) && (timeZoneCache.timeZonesByOffset.count > 0);
+}
+#endif
+
+@implementation ISO8601DateFormatter
++ (void) initialize {
+	[self createGlobalCachesThatDoNotAlreadyExist];
+}
+
++ (void) createGlobalCachesThatDoNotAlreadyExist {
+	if (!timeZoneCache) {
+		timeZoneCache = [[ISO8601TimeZoneCache alloc] init];
+	}
+}
+
++ (void) purgeGlobalCaches {
+	ISO8601TimeZoneCache *oldCache = timeZoneCache;
+	timeZoneCache = nil;
+	[oldCache release];
+}
+
+- (NSCalendar *) makeCalendarWithDesiredConfiguration {
+	NSCalendar *calendar = [[[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar] autorelease];
+	calendar.firstWeekday = 2; //Monday
+	calendar.timeZone = [NSTimeZone defaultTimeZone];
+	return calendar;
+}
+
+- (id) init {
+	if ((self = [super init])) {
+		parsingCalendar = [[self makeCalendarWithDesiredConfiguration] retain];
+		unparsingCalendar = [[self makeCalendarWithDesiredConfiguration] retain];
+
+		format = ISO8601DateFormatCalendar;
+		timeSeparator = ISO8601DefaultTimeSeparatorCharacter;
+		includeTime = NO;
+		parsesStrictly = NO;
+
+#if TARGET_OS_IPHONE
+		[[NSNotificationCenter defaultCenter] addObserver:self
+			selector:@selector(didReceiveMemoryWarning:)
+			name:UIApplicationDidReceiveMemoryWarningNotification
+			object:nil];
+#endif
+	}
+	return self;
+}
+
+- (void) dealloc {
+#if TARGET_OS_IPHONE
+	[[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
+#endif
+
+	[defaultTimeZone release];
+
+	[unparsingFormatter release];
+	[lastUsedFormatString release];
+	[parsingCalendar release];
+	[unparsingCalendar release];
+
+	[super dealloc];
+}
+
+- (void) didReceiveMemoryWarning:(NSNotification *)notification {
+	[[self class] purgeGlobalCaches];
+}
+
+@synthesize defaultTimeZone;
+- (void) setDefaultTimeZone:(NSTimeZone *)tz {
+	if (defaultTimeZone != tz) {
+		[defaultTimeZone release];
+		defaultTimeZone = [tz retain];
+
+		unparsingCalendar.timeZone = defaultTimeZone;
+	}
+}
+
+//The following properties are only here because GCC doesn't like @synthesize in category implementations.
+
+#pragma mark Parsing
+
+@synthesize parsesStrictly;
+
+static NSUInteger read_segment(const unichar *str, const unichar **next, NSUInteger *out_num_digits);
+static NSUInteger read_segment_4digits(const unichar *str, const unichar **next, NSUInteger *out_num_digits);
+static NSUInteger read_segment_2digits(const unichar *str, const unichar **next);
+static double read_double(const unichar *str, const unichar **next);
+static BOOL is_leap_year(NSUInteger year);
+
+/*Valid ISO 8601 date formats:
+ *
+ *YYYYMMDD
+ *YYYY-MM-DD
+ *YYYY-MM
+ *YYYY
+ *YY //century 
+ * //Implied century: YY is 00-99
+ *  YYMMDD
+ *  YY-MM-DD
+ * -YYMM
+ * -YY-MM
+ * -YY
+ * //Implied year
+ *  --MMDD
+ *  --MM-DD
+ *  --MM
+ * //Implied year and month
+ *   ---DD
+ * //Ordinal dates: DDD is the number of the day in the year (1-366)
+ *YYYYDDD
+ *YYYY-DDD
+ *  YYDDD
+ *  YY-DDD
+ *   -DDD
+ * //Week-based dates: ww is the number of the week, and d is the number (1-7) of the day in the week
+ *yyyyWwwd
+ *yyyy-Www-d
+ *yyyyWww
+ *yyyy-Www
+ *yyWwwd
+ *yy-Www-d
+ *yyWww
+ *yy-Www
+ * //Year of the implied decade
+ *-yWwwd
+ *-y-Www-d
+ *-yWww
+ *-y-Www
+ * //Week and day of implied year
+ *  -Wwwd
+ *  -Www-d
+ * //Week only of implied year
+ *  -Www
+ * //Day only of implied week
+ *  -W-d
+ */
+
+- (NSDateComponents *) dateComponentsFromString:(NSString *)string {
+	return [self dateComponentsFromString:string timeZone:NULL];
+}
+- (NSDateComponents *) dateComponentsFromString:(NSString *)string timeZone:(out NSTimeZone **)outTimeZone {
+	return [self dateComponentsFromString:string timeZone:outTimeZone range:NULL fractionOfSecond:NULL];
+}
+- (NSDateComponents *) dateComponentsFromString:(NSString *)string timeZone:(out NSTimeZone **)outTimeZone range:(out NSRange *)outRange fractionOfSecond:(out NSTimeInterval *)outFractionOfSecond {
+	if (string == nil)
+		return nil;
+	// Bail if the string contains a slash delimiter (we don't yet support ISO 8601 intervals and we don't support slash-separated dates)
+	if ([string rangeOfString:@"/"].location != NSNotFound)
+		return nil;
+
+	NSDate *now = [NSDate date];
+
+	NSDateComponents *components = [[[NSDateComponents alloc] init] autorelease];
+	NSDateComponents *nowComponents = [parsingCalendar components:(NSYearCalendarUnit | NSMonthCalendarUnit | NSDayCalendarUnit) fromDate:now];
+
+	NSUInteger
+		//Date
+		year,
+		month_or_week = 0U,
+		day = 0U,
+		//Time
+		hour = 0U;
+	NSTimeInterval
+		minute = 0.0,
+		second = 0.0;
+	//Time zone
+	NSInteger tz_hour = 0;
+	NSInteger tz_minute = 0;
+
+	enum {
+		monthAndDate,
+		week,
+		dateOnly
+	} dateSpecification = monthAndDate;
+
+	BOOL strict = self.parsesStrictly;
+	unichar timeSep = self.timeSeparator;
+
+	if (strict) timeSep = ISO8601DefaultTimeSeparatorCharacter;
+	NSAssert(timeSep != '\0', @"Time separator must not be NUL.");
+
+	BOOL isValidDate = ([string length] > 0U);
+	NSTimeZone *timeZone = nil;
+
+	const unichar *ch = (const unichar *)[string cStringUsingEncoding:NSUnicodeStringEncoding];
+
+	NSRange range = { 0U, 0U };
+	const unichar *start_of_date = NULL;
+	if (strict && isspace(*ch)) {
+		range.location = NSNotFound;
+		isValidDate = NO;
+	} else {
+		//Skip leading whitespace.
+		NSUInteger i = 0U;
+		while (isspace(ch[i]))
+			++i;
+
+		range.location = i;
+		ch += i;
+		start_of_date = ch;
+
+		NSUInteger segment;
+		NSUInteger num_leading_hyphens = 0U, num_digits = 0U;
+
+		if (*ch == 'T') {
+			//There is no date here, only a time. Set the date to now; then we'll parse the time.
+			isValidDate = isdigit(*++ch);
+
+			year = nowComponents.year;
+			month_or_week = nowComponents.month;
+			day = nowComponents.day;
+		} else {
+			while(*ch == '-') {
+				++num_leading_hyphens;
+				++ch;
+			}
+
+			segment = read_segment(ch, &ch, &num_digits);
+			switch(num_digits) {
+				case 0:
+					if (*ch == 'W') {
+						if ((ch[1] == '-') && isdigit(ch[2]) && ((num_leading_hyphens == 1U) || ((num_leading_hyphens == 2U) && !strict))) {
+							year = nowComponents.year;
+							month_or_week = 1U;
+							ch += 2;
+							goto parseDayAfterWeek;
+						} else if (num_leading_hyphens == 1U) {
+							year = nowComponents.year;
+							goto parseWeekAndDay;
+						} else
+							isValidDate = NO;
+					} else
+						isValidDate = NO;
+					break;
+
+				case 8: //YYYY MM DD
+					if (num_leading_hyphens > 0U)
+						isValidDate = NO;
+					else {
+						day = segment % 100U;
+						segment /= 100U;
+						month_or_week = segment % 100U;
+						year = segment / 100U;
+					}
+					break;
+
+				case 6: //YYMMDD (implicit century)
+					if (num_leading_hyphens > 0U || strict)
+						isValidDate = NO;
+					else {
+						day = segment % 100U;
+						segment /= 100U;
+						month_or_week = segment % 100U;
+						year  = nowComponents.year;
+						year -= (year % 100U);
+						year += segment / 100U;
+					}
+					break;
+
+				case 4:
+					switch(num_leading_hyphens) {
+						case 0: //YYYY
+							year = segment;
+
+							if (*ch == '-') ++ch;
+
+							if (!isdigit(*ch)) {
+								if (*ch == 'W')
+									goto parseWeekAndDay;
+								else
+									month_or_week = day = 1U;
+							} else {
+								segment = read_segment(ch, &ch, &num_digits);
+								switch(num_digits) {
+									case 4: //MMDD
+										if (strict)
+											isValidDate = NO;
+										else {
+											day = segment % 100U;
+											month_or_week = segment / 100U;
+										}
+										break;
+
+									case 2: //MM
+										month_or_week = segment;
+
+										if (*ch == '-') ++ch;
+										if (!isdigit(*ch))
+											day = 1U;
+										else
+											day = read_segment(ch, &ch, NULL);
+										break;
+
+									case 3: //DDD
+										day = segment % 1000U;
+										dateSpecification = dateOnly;
+										if (strict && (day > (365U + is_leap_year(year))))
+											isValidDate = NO;
+										break;
+
+									default:
+										isValidDate = NO;
+								}
+							}
+							break;
+
+						case 1: //YYMM
+							month_or_week = segment % 100U;
+							year = segment / 100U;
+
+							if (*ch == '-') ++ch;
+							if (!isdigit(*ch))
+								day = 1U;
+							else
+								day = read_segment(ch, &ch, NULL);
+
+							break;
+
+						case 2: //MMDD
+							day = segment % 100U;
+							month_or_week = segment / 100U;
+							year = nowComponents.year;
+
+							break;
+
+						default:
+							isValidDate = NO;
+					} //switch(num_leading_hyphens) (4 digits)
+					break;
+
+				case 1:
+					if (strict) {
+						//Two digits only - never just one.
+						if (num_leading_hyphens == 1U) {
+							if (*ch == '-') ++ch;
+							if (*++ch == 'W') {
+								year  = nowComponents.year;
+								year -= (year % 10U);
+								year += segment;
+								goto parseWeekAndDay;
+							} else
+								isValidDate = NO;
+						} else
+							isValidDate = NO;
+						break;
+					}
+				case 2:
+					switch(num_leading_hyphens) {
+						case 0:
+							if (*ch == '-') {
+								//Implicit century
+								year  = nowComponents.year;
+								year -= (year % 100U);
+								year += segment;
+
+								if (*++ch == 'W')
+									goto parseWeekAndDay;
+								else if (!isdigit(*ch)) {
+									goto centuryOnly;
+								} else {
+									//Get month and/or date.
+									segment = read_segment_4digits(ch, &ch, &num_digits);
+									NSLog(@"(%@) parsing month; segment is %lu and ch is %@", string, (unsigned long)segment, [NSString stringWithCString:(const char *)ch encoding:NSUnicodeStringEncoding]);
+									switch(num_digits) {
+										case 4: //YY-MMDD
+											day = segment % 100U;
+											month_or_week = segment / 100U;
+											break;
+
+										case 1: //YY-M; YY-M-DD (extension)
+											if (strict) {
+												isValidDate = NO;
+												break;
+											}
+										case 2: //YY-MM; YY-MM-DD
+											month_or_week = segment;
+											if (*ch == '-') {
+												if (isdigit(*++ch))
+													day = read_segment_2digits(ch, &ch);
+												else
+													day = 1U;
+											} else
+												day = 1U;
+											break;
+
+										case 3: //Ordinal date.
+											day = segment;
+											dateSpecification = dateOnly;
+											break;
+									}
+								}
+							} else if (*ch == 'W') {
+								year  = nowComponents.year;
+								year -= (year % 100U);
+								year += segment;
+
+							parseWeekAndDay: //*ch should be 'W' here.
+								if (!isdigit(*++ch)) {
+									//Not really a week-based date; just a year followed by '-W'.
+									if (strict)
+										isValidDate = NO;
+									else
+										month_or_week = day = 1U;
+								} else {
+									month_or_week = read_segment_2digits(ch, &ch);
+									if (*ch == '-') ++ch;
+								parseDayAfterWeek:
+									day = isdigit(*ch) ? read_segment_2digits(ch, &ch) : 1U;
+									dateSpecification = week;
+								}
+							} else {
+								//Century only. Assume current year.
+							centuryOnly:
+								year = segment * 100U + nowComponents.year % 100U;
+								month_or_week = day = 1U;
+							}
+							break;
+
+						case 1:; //-YY; -YY-MM (implicit century)
+							NSLog(@"(%@) found %lu digits and one hyphen, so this is either -YY or -YY-MM; segment (year) is %lu", string, (unsigned long)num_digits, (unsigned long)segment);
+							NSUInteger current_year = nowComponents.year;
+							NSUInteger current_century = (current_year % 100U);
+							year = segment + (current_year - current_century);
+							if (num_digits == 1U) //implied decade
+								year += current_century - (current_year % 10U);
+
+							if (*ch == '-') {
+								++ch;
+								month_or_week = read_segment_2digits(ch, &ch);
+								NSLog(@"(%@) month is %lu", string, (unsigned long)month_or_week);
+							}
+
+							day = 1U;
+							break;
+
+						case 2: //--MM; --MM-DD
+							year = nowComponents.year;
+							month_or_week = segment;
+							if (*ch == '-') {
+								++ch;
+								day = read_segment_2digits(ch, &ch);
+							}
+							break;
+
+						case 3: //---DD
+							year = nowComponents.year;
+							month_or_week = nowComponents.month;
+							day = segment;
+							break;
+
+						default:
+							isValidDate = NO;
+					} //switch(num_leading_hyphens) (2 digits)
+					break;
+
+				case 7: //YYYY DDD (ordinal date)
+					if (num_leading_hyphens > 0U)
+						isValidDate = NO;
+					else {
+						day = segment % 1000U;
+						year = segment / 1000U;
+						dateSpecification = dateOnly;
+						if (strict && (day > (365U + is_leap_year(year))))
+							isValidDate = NO;
+					}
+					break;
+
+				case 3: //--DDD (ordinal date, implicit year)
+					//Technically, the standard only allows one hyphen. But it says that two hyphens is the logical implementation, and one was dropped for brevity. So I have chosen to allow the missing hyphen.
+					if ((num_leading_hyphens < 1U) || ((num_leading_hyphens > 2U) && !strict))
+						isValidDate = NO;
+					else {
+						day = segment;
+						year = nowComponents.year;
+						dateSpecification = dateOnly;
+						if (strict && (day > (365U + is_leap_year(year))))
+							isValidDate = NO;
+					}
+					break;
+
+				default:
+					isValidDate = NO;
+			}
+		}
+
+		if (isValidDate) {
+			if (isspace(*ch) || (*ch == 'T')) ++ch;
+
+			if (isdigit(*ch)) {
+				hour = read_segment_2digits(ch, &ch);
+				if (*ch == timeSep) {
+					++ch;
+					if ((timeSep == ',') || (timeSep == '.')) {
+						//We can't do fractional minutes when '.' is the segment separator.
+						//Only allow whole minutes and whole seconds.
+						minute = read_segment_2digits(ch, &ch);
+						if (*ch == timeSep) {
+							++ch;
+							second = read_segment_2digits(ch, &ch);
+						}
+					} else {
+						//Allow a fractional minute.
+						//If we don't get a fraction, look for a seconds segment.
+						//Otherwise, the fraction of a minute is the seconds.
+						minute = read_double(ch, &ch);
+						second = modf(minute, &minute);
+						if (second > DBL_EPSILON)
+							second *= 60.0; //Convert fraction (e.g. .5) into seconds (e.g. 30).
+						else if (*ch == timeSep) {
+							++ch;
+							second = read_double(ch, &ch);
+						}
+					}
+				}
+
+				if (!strict) {
+					if (isspace(*ch)) ++ch;
+				}
+
+				switch(*ch) {
+					case 'Z':
+						timeZone = [NSTimeZone timeZoneWithAbbreviation:@"UTC"];
+						++ch; //So that the Z is included in the range.
+						break;
+
+					case '+':
+					case '-':;
+						BOOL negative = (*ch == '-');
+						if (isdigit(*++ch)) {
+							//Read hour offset.
+							segment = *ch - '0';
+							if (isdigit(*++ch)) {
+								segment *= 10U;
+								segment += *(ch++) - '0';
+							}
+							tz_hour = (NSInteger)segment;
+							if (negative) tz_hour = -tz_hour;
+
+							//Optional separator.
+							if (*ch == self.timeZoneSeparator) ++ch;
+
+							if (isdigit(*ch)) {
+								//Read minute offset.
+								segment = *ch - '0';
+								if (isdigit(*++ch)) {
+									segment *= 10U;
+									segment += *ch - '0';
+								}
+								tz_minute = segment;
+								if (negative) tz_minute = -tz_minute;
+							}
+
+							[[self class] createGlobalCachesThatDoNotAlreadyExist];
+
+							NSInteger timeZoneOffset = (tz_hour * 3600) + (tz_minute * 60);
+							NSNumber *offsetNum = [NSNumber numberWithInteger:timeZoneOffset];
+							timeZone = [timeZoneCache.timeZonesByOffset objectForKey:offsetNum];
+							if (!timeZone) {
+								timeZone = [NSTimeZone timeZoneForSecondsFromGMT:timeZoneOffset];
+								if (timeZone)
+									[timeZoneCache.timeZonesByOffset setObject:timeZone forKey:offsetNum];
+							}
+						}
+				}
+			}
+		}
+
+		if (isValidDate) {
+			components.year = year;
+			components.day = day;
+			components.hour = hour;
+			components.minute = (NSInteger)minute;
+			components.second = (NSInteger)second;
+
+			if (outFractionOfSecond != NULL) {
+				NSTimeInterval fractionOfSecond = second - components.second;
+				if (fractionOfSecond > 0.0) {
+					*outFractionOfSecond = fractionOfSecond;
+				}
+			}
+
+			switch(dateSpecification) {
+				case monthAndDate:
+					components.month = month_or_week;
+					break;
+
+				case week:;
+					//Adapted from <http://personal.ecu.edu/mccartyr/ISOwdALG.txt>.
+					//This works by converting the week date into an ordinal date, then letting the next case handle it.
+					NSUInteger prevYear = year - 1U;
+					NSUInteger YY = prevYear % 100U;
+					NSUInteger C = prevYear - YY;
+					NSUInteger G = YY + YY / 4U;
+					NSUInteger isLeapYear = (((C / 100U) % 4U) * 5U);
+					NSUInteger Jan1Weekday = (isLeapYear + G) % 7U;
+					enum { monday, tuesday, wednesday, thursday/*, friday, saturday, sunday*/ };
+					components.day = ((8U - Jan1Weekday) + (7U * (Jan1Weekday > thursday))) + (day - 1U) + (7U * (month_or_week - 2));
+
+				case dateOnly: //An "ordinal date".
+					break;
+			}
+		}
+	} //if (!(strict && isdigit(ch[0])))
+
+	if (outRange) {
+		if (isValidDate)
+			range.length = ch - start_of_date;
+		else
+			range.location = NSNotFound;
+
+		*outRange = range;
+	}
+	if (outTimeZone) {
+		*outTimeZone = timeZone;
+	}
+
+	return isValidDate ? components : nil;
+}
+
+- (NSDate *) dateFromString:(NSString *)string {
+	return [self dateFromString:string timeZone:NULL];
+}
+- (NSDate *) dateFromString:(NSString *)string timeZone:(out NSTimeZone **)outTimeZone {
+	return [self dateFromString:string timeZone:outTimeZone range:NULL];
+}
+- (NSDate *) dateFromString:(NSString *)string timeZone:(out NSTimeZone **)outTimeZone range:(out NSRange *)outRange {
+	NSTimeZone *timeZone = nil;
+	NSTimeInterval parsedFractionOfSecond = 0.0;
+  
+	NSDateComponents *components = [self dateComponentsFromString:string timeZone:&timeZone range:outRange fractionOfSecond:&parsedFractionOfSecond];
+
+	if (outTimeZone)
+		*outTimeZone = timeZone;
+	if (components == nil)
+		return nil;
+
+	parsingCalendar.timeZone = timeZone;
+
+	NSDate *parsedDate = [parsingCalendar dateFromComponents:components];
+
+	if (parsedFractionOfSecond > 0.0) {
+		parsedDate = [parsedDate dateByAddingTimeInterval:parsedFractionOfSecond];
+	}
+  
+  return parsedDate;
+}
+
+- (BOOL)getObjectValue:(id *)outValue forString:(NSString *)string errorDescription:(NSString **)error {
+	NSDate *date = [self dateFromString:string];
+	if (outValue)
+		*outValue = date;
+	return (date != nil);
+}
+
+#pragma mark Unparsing
+
+@synthesize format;
+@synthesize includeTime;
+@synthesize timeSeparator;
+@synthesize timeZoneSeparator;
+
+- (NSString *) replaceColonsInString:(NSString *)timeFormat withTimeSeparator:(unichar)timeSep {
+	if (timeSep != ':') {
+		NSMutableString *timeFormatMutable = [[timeFormat mutableCopy] autorelease];
+		[timeFormatMutable replaceOccurrencesOfString:@":"
+		                               	   withString:[NSString stringWithCharacters:&timeSep length:1U]
+	                                      	  options:NSBackwardsSearch | NSLiteralSearch
+	                                        	range:(NSRange){ 0UL, [timeFormat length] }];
+		timeFormat = timeFormatMutable;
+	}
+	return timeFormat;
+}
+
+- (NSString *) stringFromDate:(NSDate *)date {
+	NSTimeZone *timeZone = self.defaultTimeZone;
+	if (!timeZone) timeZone = [NSTimeZone defaultTimeZone];
+	return [self stringFromDate:date timeZone:timeZone];
+}
+
+- (NSString *) stringFromDate:(NSDate *)date timeZone:(NSTimeZone *)timeZone {
+	switch (self.format) {
+		case ISO8601DateFormatCalendar:
+			return [self stringFromDate:date formatString:ISO_CALENDAR_DATE_FORMAT timeZone:timeZone];
+		case ISO8601DateFormatWeek:
+			return [self weekDateStringForDate:date timeZone:timeZone];
+		case ISO8601DateFormatOrdinal:
+			return [self stringFromDate:date formatString:ISO_ORDINAL_DATE_FORMAT timeZone:timeZone];
+		default:
+			[NSException raise:NSInternalInconsistencyException format:@"self.format was %tu, not calendar (%tu), week (%tu), or ordinal (%tu)", self.format, ISO8601DateFormatCalendar, ISO8601DateFormatWeek, ISO8601DateFormatOrdinal];
+			return nil;
+	}
+}
+
+- (NSString *) stringFromDate:(NSDate *)date formatString:(NSString *)dateFormat timeZone:(NSTimeZone *)timeZone {
+	if (includeTime)
+		dateFormat = [dateFormat stringByAppendingFormat:@"'T'%@", [self replaceColonsInString:ISO_TIME_FORMAT withTimeSeparator:self.timeSeparator]];
+
+	if ([dateFormat isEqualToString:lastUsedFormatString] == NO) {
+		[unparsingFormatter release];
+		unparsingFormatter = nil;
+
+		[lastUsedFormatString release];
+		lastUsedFormatString = [dateFormat retain];
+	}
+
+	if (!unparsingFormatter) {
+		unparsingFormatter = [[NSDateFormatter alloc] init];
+		unparsingFormatter.formatterBehavior = NSDateFormatterBehavior10_4;
+		unparsingFormatter.dateFormat = dateFormat;
+		unparsingFormatter.calendar = unparsingCalendar;
+		unparsingFormatter.locale = [[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"] autorelease];
+	}
+
+	unparsingCalendar.timeZone = timeZone;
+	unparsingFormatter.timeZone = timeZone;
+	NSString *str = [unparsingFormatter stringForObjectValue:date];
+
+	if (includeTime) {
+		NSInteger offset = [timeZone secondsFromGMTForDate:date];
+		offset /= 60;  //bring down to minutes
+		if (offset == 0)
+			str = [str stringByAppendingString:ISO_TIMEZONE_UTC_FORMAT];
+		else {
+			int timeZoneOffsetHour = abs((int)(offset / 60));
+			int timeZoneOffsetMinute = abs((int)(offset % 60));
+            
+            if (offset > 0) str = [str stringByAppendingString:@"+"];
+            else str = [str stringByAppendingString:@"-"];
+            
+            str = [str stringByAppendingFormat:ISO8601TwoCharIntegerFormat, timeZoneOffsetHour];
+            
+            if (self.timeZoneSeparator) str = [str stringByAppendingFormat:@"%C", self.timeZoneSeparator];
+            
+            str = [str stringByAppendingFormat:ISO8601TwoCharIntegerFormat, timeZoneOffsetMinute];
+		}
+	}
+
+	//Undo the change we made earlier
+	unparsingCalendar.timeZone = self.defaultTimeZone;
+	unparsingFormatter.timeZone = self.defaultTimeZone;
+
+	return str;
+}
+
+- (NSString *) stringForObjectValue:(id)value {
+	if ( ! [value isKindOfClass:[NSDate class]]) {
+		NSLog(@"%s: Can only format NSDate objects, not objects like %@", __func__, value);
+		return nil;
+	}
+
+	return [self stringFromDate:(NSDate *)value];
+}
+
+/*Adapted from:
+ *	Algorithm for Converting Gregorian Dates to ISO 8601 Week Date
+ *	Rick McCarty, 1999
+ *	http://personal.ecu.edu/mccartyr/ISOwdALG.txt
+ */
+- (NSString *) weekDateStringForDate:(NSDate *)date timeZone:(NSTimeZone *)timeZone {
+	unparsingCalendar.timeZone = timeZone;
+	NSDateComponents *components = [unparsingCalendar components:NSYearCalendarUnit | NSWeekdayCalendarUnit | NSDayCalendarUnit fromDate:date];
+
+	//Determine the ordinal date.
+	NSDateComponents *startOfYearComponents = [unparsingCalendar components:NSYearCalendarUnit fromDate:date];
+	startOfYearComponents.month = 1;
+	startOfYearComponents.day = 1;
+	NSDateComponents *ordinalComponents = [unparsingCalendar components:NSDayCalendarUnit fromDate:[unparsingCalendar dateFromComponents:startOfYearComponents] toDate:date options:0];
+	ordinalComponents.day += 1;
+
+	enum {
+		monday, tuesday, wednesday, thursday, friday, saturday, sunday
+	};
+	enum {
+		january = 1, february, march,
+		april, may, june,
+		july, august, september,
+		october, november, december
+	};
+
+	NSInteger year = components.year;
+	NSInteger week = 0;
+	//The old unparser added 6 to [calendarDate dayOfWeek], which was zero-based; components.weekday is one-based, so we now add only 5.
+	NSInteger dayOfWeek = (components.weekday + 5) % 7;
+	NSInteger dayOfYear = ordinalComponents.day;
+
+	NSInteger prevYear = year - 1;
+
+	BOOL yearIsLeapYear = is_leap_year(year);
+	BOOL prevYearIsLeapYear = is_leap_year(prevYear);
+
+	NSInteger YY = prevYear % 100;
+	NSInteger C = prevYear - YY;
+	NSInteger G = YY + YY / 4;
+	NSInteger Jan1Weekday = (((((C / 100) % 4) * 5) + G) % 7);
+
+	NSInteger weekday = ((dayOfYear + Jan1Weekday) - 1) % 7;
+
+	if((dayOfYear <= (7 - Jan1Weekday)) && (Jan1Weekday > thursday)) {
+		week = 52 + ((Jan1Weekday == friday) || ((Jan1Weekday == saturday) && prevYearIsLeapYear));
+		--year;
+	} else {
+		NSInteger lengthOfYear = 365 + yearIsLeapYear;
+		if((lengthOfYear - dayOfYear) < (thursday - weekday)) {
+			++year;
+			week = 1;
+		} else {
+			NSInteger J = dayOfYear + (sunday - weekday) + Jan1Weekday;
+			week = J / 7 - (Jan1Weekday > thursday);
+		}
+	}
+
+	NSString *string = [NSString stringWithFormat:@"%lu-W%02lu-%02lu", (unsigned long)year, (unsigned long)week, ((unsigned long)dayOfWeek) + 1U];
+
+	NSString *timeString;
+	if(includeTime) {
+		NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+		unichar timeSep = self.timeSeparator;
+		if (!timeSep) timeSep = ISO8601DefaultTimeSeparatorCharacter;
+		formatter.dateFormat = [self replaceColonsInString:ISO_TIME_FORMAT withTimeSeparator:timeSep];
+		formatter.locale = [[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"] autorelease];
+		formatter.timeZone = timeZone;
+
+		timeString = [formatter stringForObjectValue:date];
+
+		[formatter release];
+
+		//TODO: This is copied from the calendar-date code. It should be isolated in a method.
+		NSInteger offset = [timeZone secondsFromGMTForDate:date];
+		offset /= 60;  //bring down to minutes
+		if (offset == 0)
+			timeString = [timeString stringByAppendingString:ISO_TIMEZONE_UTC_FORMAT];
+		else {
+			int timeZoneOffsetHour = (int)(offset / 60);
+			int timeZoneOffsetMinute = (int)(offset % 60);
+			if (self.timeZoneSeparator)
+				timeString = [timeString stringByAppendingFormat:ISO_TIMEZONE_OFFSET_FORMAT_WITH_SEPARATOR,
+				                                                 timeZoneOffsetHour, self.timeZoneSeparator,
+				                                                 timeZoneOffsetMinute];
+			else
+				timeString = [timeString stringByAppendingFormat:ISO_TIMEZONE_OFFSET_FORMAT_NO_SEPARATOR,
+				                                                 timeZoneOffsetHour, timeZoneOffsetMinute];
+		}
+
+		string = [string stringByAppendingFormat:@"T%@", timeString];
+	}
+
+	return string;
+}
+
+@end
+
+static NSUInteger read_segment(const unichar *str, const unichar **next, NSUInteger *out_num_digits) {
+	NSUInteger num_digits = 0U;
+	NSUInteger value = 0U;
+
+	while(isdigit(*str)) {
+		value *= 10U;
+		value += *str - '0';
+		++num_digits;
+		++str;
+	}
+
+	if (next) *next = str;
+	if (out_num_digits) *out_num_digits = num_digits;
+
+	return value;
+}
+static NSUInteger read_segment_4digits(const unichar *str, const unichar **next, NSUInteger *out_num_digits) {
+	NSUInteger num_digits = 0U;
+	NSUInteger value = 0U;
+
+	if (isdigit(*str)) {
+		value += *(str++) - '0';
+		++num_digits;
+	}
+
+	if (isdigit(*str)) {
+		value *= 10U;
+		value += *(str++) - '0';
+		++num_digits;
+	}
+
+	if (isdigit(*str)) {
+		value *= 10U;
+		value += *(str++) - '0';
+		++num_digits;
+	}
+
+	if (isdigit(*str)) {
+		value *= 10U;
+		value += *(str++) - '0';
+		++num_digits;
+	}
+
+	if (next) *next = str;
+	if (out_num_digits) *out_num_digits = num_digits;
+
+	return value;
+}
+static NSUInteger read_segment_2digits(const unichar *str, const unichar **next) {
+	NSUInteger value = 0U;
+
+	if (isdigit(*str))
+		value += *str - '0';
+
+	if (isdigit(*++str)) {
+		value *= 10U;
+		value += *(str++) - '0';
+	}
+
+	if (next) *next = str;
+
+	return value;
+}
+
+//strtod doesn't support ',' as a separator. This does.
+static double read_double(const unichar *str, const unichar **next) {
+	double value = 0.0;
+
+	if (str) {
+		NSUInteger int_value = 0;
+
+		while(isdigit(*str)) {
+			int_value *= 10U;
+			int_value += (*(str++) - '0');
+		}
+		value = int_value;
+
+		if (((*str == ',') || (*str == '.'))) {
+			++str;
+
+			register double multiplier, multiplier_multiplier;
+			multiplier = multiplier_multiplier = 0.1;
+
+			while(isdigit(*str)) {
+				value += (*(str++) - '0') * multiplier;
+				multiplier *= multiplier_multiplier;
+			}
+		}
+	}
+
+	if (next) *next = str;
+
+	return value;
+}
+
+static BOOL is_leap_year(NSUInteger year) {
+	return \
+	    ((year %   4U) == 0U)
+	&& (((year % 100U) != 0U)
+	||  ((year % 400U) == 0U));
+}
+
+static NSString *const ISO8601ThreadStorageTimeZoneCacheKey = @"org.boredzo.ISO8601ThreadStorageTimeZoneCacheKey";
+
+@implementation ISO8601TimeZoneCache: NSObject
+
+- (NSMutableDictionary *) timeZonesByOffset {
+	NSMutableDictionary *threadDict = [NSThread currentThread].threadDictionary;
+	NSMutableDictionary *currentCacheDict = [threadDict objectForKey:ISO8601ThreadStorageTimeZoneCacheKey];
+	if (currentCacheDict == nil) {
+		currentCacheDict = [NSMutableDictionary dictionaryWithCapacity:2UL];
+		[threadDict setObject:currentCacheDict forKey:ISO8601ThreadStorageTimeZoneCacheKey];
+	}
+	return currentCacheDict;
+}
+
+@end


### PR DESCRIPTION
Native iOS date formatting results time zone differences, using third-party ISO8601 formatter class to avoid.
